### PR TITLE
Implements gh-pages support

### DIFF
--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -17,4 +17,7 @@ jobs:
           check-latest: true
       - run: npm --no-color install
       - run: npm run build
-      - run: ./node_modules/.bin/gh-pages -d build --repo "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -16,4 +16,5 @@ jobs:
           node-version: '14'
           check-latest: true
       - run: npm --no-color install
+      - run: npm run build
       - run: ./node_modules/.bin/gh-pages -d build --repo "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -16,4 +16,4 @@ jobs:
           node-version: '14'
           check-latest: true
       - run: npm --no-color install
-      - run: npm --no-color run deploy -- --repo "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
+      - run: ./node_modules/.bin/gh-pages -d build --repo "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -16,4 +16,4 @@ jobs:
           node-version: '14'
           check-latest: true
       - run: npm --no-color install
-      - run: npm --no-color run deploy -- --repo "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$INPUT_REPO.git"
+      - run: npm --no-color run deploy -- --repo "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -1,4 +1,4 @@
-name: cobrowse-evidence-flow
+name: cobrowse-agent-sdk-examples-build
 on:
   push:
     branches:
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: fregante/setup-git-user@v1
       - uses: actions/setup-node@v2
         with:
           node-version: '14'

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -16,4 +16,4 @@ jobs:
           node-version: '14'
           check-latest: true
       - run: npm --no-color install
-      - run: npm --no-color run deploy
+      - run: npm --no-color run deploy -- --repo "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$INPUT_REPO.git"

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -1,0 +1,18 @@
+name: cobrowse-evidence-flow
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  gh-pages:
+    name: Github Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          check-latest: true
+      - run: npm --no-color install
+      - run: npm --no-color run deploy

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -21,3 +21,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
+          enable_jekyll: true

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: fregante/setup-git-user@v1
       - uses: actions/setup-node@v2
         with:
           node-version: '14'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 recording-download/recordings
 private.pem
+build
+# We don't need this for running top-level commands.
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -4,15 +4,24 @@ Full documentation available at https://docs.cobrowse.io/agent-side-integrations
 
 ## Overview
 
-Our Agent API can be used to build 100% customized agent-side integrations into your own products and services. 
+Our Agent API can be used to build 100% customized agent-side integrations into your own products and services.
 
-## Quick start
+## Live demo links
 
-Navigate to our [Agent JS API Demo Page](https://cobrowse-agent-sdk-examples.cbrws.io/) and open up our [Cobrowse.io Online Demo](https://cobrowse.io/demo) in another browser tab to generate your Demo ID. 
+- [Agent JS API Demo Page](https://cobrowseio.github.io/cobrowse-agent-sdk-examples/react-example/)
+- [Custom Agent Demo Page](https://cobrowseio.github.io/cobrowse-agent-sdk-examples/custom-agent-demo/)
+
+## React Example
+
+Our React example demonstrates custom widgets to show how you can completely customize your Cobrowse.io experience.
+
+### Quick start
+
+Navigate to our [Agent JS API Demo Page](https://cobrowseio.github.io/cobrowse-agent-sdk-examples/react-example/) and open up our [Cobrowse.io Online Demo](https://cobrowse.io/demo) in another browser tab to generate your Demo ID. 
 
 This Demo Page uses our [Agent UI component library](https://github.com/cobrowseio/cobrowse-agent-ui), our [Agent JS API (JavaScript SDK)](https://www.npmjs.com/package/cobrowse-agent-sdk), and ties it together into this example project which you can run locally. 
 
-## Run locally
+### Run locally
 ```sh
 git clone git@github.com:cobrowseio/cobrowse-agent-sdk-examples.git
 cd cobrowse-agent-sdk-examples
@@ -21,6 +30,24 @@ npm install
 npm start
 ```
 
+## Custom Agent Demo
+
+Our custom agent demo allows you to view and interact with a completely replaced agent user interface.
+
+### Quick start
+
+Navigate to our [Custom Agent Demo Page](https://cobrowseio.github.io/cobrowse-agent-sdk-examples/custom-agent-demo/) to automatically start an agent session and simulate the agent and customer experience.
+
+This Demo Page uses our [Agent JS API (JavaScript SDK)](https://www.npmjs.com/package/cobrowse-agent-sdk) in this example project which you can run locally. 
+
+### Run locally
+```sh
+git clone git@github.com:cobrowseio/cobrowse-agent-sdk-examples.git
+cd cobrowse-agent-sdk-examples
+cd custom-agent-demo
+npm install
+npm start
+```
 
 ## Questions?
 Any questions at all? Please email us directly at [hello@cobrowse.io](mailto:hello@cobrowse.io).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Our Agent API can be used to build 100% customized agent-side integrations into 
 
 ## React Example
 
-Our React example demonstrates custom widgets to show how you can completely customize your Cobrowse.io experience.
+Our [React example](https://cobrowseio.github.io/cobrowse-agent-sdk-examples/react-example/) demonstrates custom widgets to show how you can completely customize your Cobrowse.io experience.
 
 ### Quick start
 
@@ -32,7 +32,7 @@ npm start
 
 ## Custom Agent Demo
 
-Our custom agent demo allows you to view and interact with a completely replaced agent user interface.
+Our [custom agent demo](https://cobrowseio.github.io/cobrowse-agent-sdk-examples/custom-agent-demo/) allows you to view and interact with a completely replaced agent user interface.
 
 ### Quick start
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Our Agent API can be used to build 100% customized agent-side integrations into 
 
 ## Live demo links
 
-- [Agent JS API Demo Page](https://aaronhuggins.github.io/cobrowse-agent-sdk-examples/react-example/)
-- [Custom Agent Demo Page](https://aaronhuggins.github.io/cobrowse-agent-sdk-examples/custom-agent-demo/)
+- [Agent JS API Demo Page](https://cobrowseio.github.io/cobrowse-agent-sdk-examples/react-example/)
+- [Custom Agent Demo Page](https://cobrowseio.github.io/cobrowse-agent-sdk-examples/custom-agent-demo/)
 
 ## React Example
 
@@ -17,7 +17,7 @@ Our React example demonstrates custom widgets to show how you can completely cus
 
 ### Quick start
 
-Navigate to our [Agent JS API Demo Page](https://aaronhuggins.github.io/cobrowse-agent-sdk-examples/react-example/) and open up our [Cobrowse.io Online Demo](https://cobrowse.io/demo) in another browser tab to generate your Demo ID. 
+Navigate to our [Agent JS API Demo Page](https://cobrowseio.github.io/cobrowse-agent-sdk-examples/react-example/) and open up our [Cobrowse.io Online Demo](https://cobrowse.io/demo) in another browser tab to generate your Demo ID. 
 
 This Demo Page uses our [Agent UI component library](https://github.com/cobrowseio/cobrowse-agent-ui), our [Agent JS API (JavaScript SDK)](https://www.npmjs.com/package/cobrowse-agent-sdk), and ties it together into this example project which you can run locally. 
 
@@ -36,7 +36,7 @@ Our custom agent demo allows you to view and interact with a completely replaced
 
 ### Quick start
 
-Navigate to our [Custom Agent Demo Page](https://aaronhuggins.github.io/cobrowse-agent-sdk-examples/custom-agent-demo/) to automatically start an agent session and simulate the agent and customer experience.
+Navigate to our [Custom Agent Demo Page](https://cobrowseio.github.io/cobrowse-agent-sdk-examples/custom-agent-demo/) to automatically start an agent session and simulate the agent and customer experience.
 
 This Demo Page uses our [Agent JS API (JavaScript SDK)](https://www.npmjs.com/package/cobrowse-agent-sdk) in this example project which you can run locally. 
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Our Agent API can be used to build 100% customized agent-side integrations into 
 
 ## Live demo links
 
-- [Agent JS API Demo Page](https://cobrowseio.github.io/cobrowse-agent-sdk-examples/react-example/)
-- [Custom Agent Demo Page](https://cobrowseio.github.io/cobrowse-agent-sdk-examples/custom-agent-demo/)
+- [Agent JS API Demo Page](https://aaronhuggins.github.io/cobrowse-agent-sdk-examples/react-example/)
+- [Custom Agent Demo Page](https://aaronhuggins.github.io/cobrowse-agent-sdk-examples/custom-agent-demo/)
 
 ## React Example
 
@@ -17,7 +17,7 @@ Our React example demonstrates custom widgets to show how you can completely cus
 
 ### Quick start
 
-Navigate to our [Agent JS API Demo Page](https://cobrowseio.github.io/cobrowse-agent-sdk-examples/react-example/) and open up our [Cobrowse.io Online Demo](https://cobrowse.io/demo) in another browser tab to generate your Demo ID. 
+Navigate to our [Agent JS API Demo Page](https://aaronhuggins.github.io/cobrowse-agent-sdk-examples/react-example/) and open up our [Cobrowse.io Online Demo](https://cobrowse.io/demo) in another browser tab to generate your Demo ID. 
 
 This Demo Page uses our [Agent UI component library](https://github.com/cobrowseio/cobrowse-agent-ui), our [Agent JS API (JavaScript SDK)](https://www.npmjs.com/package/cobrowse-agent-sdk), and ties it together into this example project which you can run locally. 
 
@@ -36,7 +36,7 @@ Our custom agent demo allows you to view and interact with a completely replaced
 
 ### Quick start
 
-Navigate to our [Custom Agent Demo Page](https://cobrowseio.github.io/cobrowse-agent-sdk-examples/custom-agent-demo/) to automatically start an agent session and simulate the agent and customer experience.
+Navigate to our [Custom Agent Demo Page](https://aaronhuggins.github.io/cobrowse-agent-sdk-examples/custom-agent-demo/) to automatically start an agent session and simulate the agent and customer experience.
 
 This Demo Page uses our [Agent JS API (JavaScript SDK)](https://www.npmjs.com/package/cobrowse-agent-sdk) in this example project which you can run locally. 
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+if [ -d "./build" ]; then
+  rm -rf ./build
+fi
+
+mkdir "./build"
+
+function react_build () {
+  PWD_CACHE="$PWD"
+  cd $1
+  npm install
+  npm run build
+  cd $PWD_CACHE
+}
+
+function copy_build () {
+  mkdir -p "./build/${1}"
+  cp -rf "./${1}/build/." "./build/${1}/"
+}
+
+react_build "custom-agent-demo"
+copy_build "custom-agent-demo"
+react_build "react-example"
+copy_build "react-example"
+
+cp -f "./README.md" "./build/"

--- a/custom-agent-demo/package-lock.json
+++ b/custom-agent-demo/package-lock.json
@@ -5123,12 +5123,6 @@
         }
       }
     },
-    "email-addresses": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.1.0.tgz",
-      "integrity": "sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg==",
-      "dev": true
-    },
     "emittery": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
@@ -6336,23 +6330,6 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "optional": true
     },
-    "filename-reserved-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
-      "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
-      "dev": true
-    },
-    "filenamify": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
-      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
-      "dev": true,
-      "requires": {
-        "filename-reserved-regex": "^2.0.0",
-        "strip-outer": "^1.0.1",
-        "trim-repeated": "^1.0.0"
-      }
-    },
     "filesize": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
@@ -6707,118 +6684,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
-    },
-    "gh-pages": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-3.2.3.tgz",
-      "integrity": "sha512-jA1PbapQ1jqzacECfjUaO9gV8uBgU6XNMV0oXLtfCX3haGLe5Atq8BxlrADhbD6/UdG9j6tZLWAkAybndOXTJg==",
-      "dev": true,
-      "requires": {
-        "async": "^2.6.1",
-        "commander": "^2.18.0",
-        "email-addresses": "^3.0.1",
-        "filenamify": "^4.3.0",
-        "find-cache-dir": "^3.3.1",
-        "fs-extra": "^8.1.0",
-        "globby": "^6.1.0"
-      },
-      "dependencies": {
-        "array-union": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-          "dev": true,
-          "requires": {
-            "array-uniq": "^1.0.1"
-          }
-        },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
-        },
-        "find-cache-dir": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-          "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-          "dev": true,
-          "requires": {
-            "commondir": "^1.0.1",
-            "make-dir": "^3.0.2",
-            "pkg-dir": "^4.1.0"
-          }
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "dev": true,
-          "requires": {
-            "array-union": "^1.0.1",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "make-dir": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-          "dev": true,
-          "requires": {
-            "semver": "^6.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-          "dev": true,
-          "requires": {
-            "find-up": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-          "dev": true
-        }
-      }
     },
     "glob": {
       "version": "7.2.0",
@@ -13728,15 +13593,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
-    "strip-outer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "^1.0.2"
-      }
-    },
     "style-loader": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.3.0.tgz",
@@ -14160,15 +14016,6 @@
       "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
       "requires": {
         "punycode": "^2.1.1"
-      }
-    },
-    "trim-repeated": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
-      "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "^1.0.2"
       }
     },
     "tryer": {

--- a/custom-agent-demo/package-lock.json
+++ b/custom-agent-demo/package-lock.json
@@ -3990,9 +3990,9 @@
       }
     },
     "cobrowse-agent-sdk": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/cobrowse-agent-sdk/-/cobrowse-agent-sdk-0.0.13.tgz",
-      "integrity": "sha512-bClrSTDIKnF+6pfcjQtkwbg2qfTTx70o65pqAcjHwx8H8yThtlFoFCEAuHxz941c9kjAfvPzgSRzLuU38mcxaQ==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/cobrowse-agent-sdk/-/cobrowse-agent-sdk-0.0.14.tgz",
+      "integrity": "sha512-XYV2JyFnxSr6LuVVokMJ0lDTc1mYw3mj+/y1M6N277o5fd/pesq3sAjRKq7kXJWTAQ3t9+5ftXk6gJQFb32/nw==",
       "requires": {
         "@arduino/cbor-js": "github:cobrowseio/cbor-js",
         "core-js": "^3.18.3",

--- a/custom-agent-demo/package.json
+++ b/custom-agent-demo/package.json
@@ -2,6 +2,7 @@
   "name": "custom-agent-demo",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://cobrowseio.github.io/cobrowse-agent-sdk-examples/custom-agent-demo",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
@@ -13,6 +14,8 @@
     "react-scripts": "4.0.3"
   },
   "scripts": {
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -b master -d build",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/custom-agent-demo/package.json
+++ b/custom-agent-demo/package.json
@@ -14,8 +14,6 @@
     "react-scripts": "4.0.3"
   },
   "scripts": {
-    "predeploy": "npm run build",
-    "deploy": "gh-pages -b master -d build",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
@@ -38,8 +36,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "devDependencies": {
-    "gh-pages": "^3.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "cobrowse-agent-sdk-examples",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Dummy package for github pages build.",
+  "main": "\"\"",
+  "scripts": {
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d build",
+    "build": "./build.sh"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aaronhuggins/cobrowse-agent-sdk-examples.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/aaronhuggins/cobrowse-agent-sdk-examples/issues"
+  },
+  "homepage": "https://github.com/aaronhuggins/cobrowse-agent-sdk-examples#readme",
+  "devDependencies": {
+    "gh-pages": "^3.2.3"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/aaronhuggins/cobrowse-agent-sdk-examples.git"
+    "url": "git+https://github.com/cobrowseio/cobrowse-agent-sdk-examples.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/aaronhuggins/cobrowse-agent-sdk-examples/issues"
+    "url": "https://github.com/cobrowseio/cobrowse-agent-sdk-examples/issues"
   },
-  "homepage": "https://github.com/aaronhuggins/cobrowse-agent-sdk-examples#readme",
+  "homepage": "https://github.com/cobrowseio/cobrowse-agent-sdk-examples#readme",
   "devDependencies": {
     "gh-pages": "^3.2.3"
   }

--- a/react-example/package-lock.json
+++ b/react-example/package-lock.json
@@ -3911,6 +3911,22 @@
         "moment": "^2.29.1",
         "react": "^17.0.2",
         "ua-parser-js": "^0.7.28"
+      },
+      "dependencies": {
+        "react": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+          "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "ua-parser-js": {
+          "version": "0.7.31",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
+          "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ=="
+        }
       }
     },
     "collect-v8-coverage": {
@@ -14458,11 +14474,6 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
-    },
-    "ua-parser-js": {
-      "version": "0.7.23",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
-      "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/react-example/package.json
+++ b/react-example/package.json
@@ -2,6 +2,7 @@
   "name": "react-example",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://cobrowseio.github.io/cobrowse-agent-sdk-examples/react-example",
   "dependencies": {
     "cobrowse-agent-sdk": "0.0.3",
     "cobrowse-agent-ui": "github:cobrowseio/cobrowse-agent-ui",


### PR DESCRIPTION
@headlessme @snyderj Running `npm install && npm run deploy` should build the react apps and assemple the github pages site in the `./build` directory, and then deploy the `./build` dir to a `gh-pages` branch contianing only the readme and demo site.

Sample is live at https://aaronhuggins.github.io/cobrowse-agent-sdk-examples/